### PR TITLE
fix(Dockerfile): fix incorrect permission for /assets/wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ EXPOSE 443 80 22
 # Define data volumes
 VOLUME ["/etc/gitlab", "/var/opt/gitlab", "/var/log/gitlab"]
 
+# ensure /assets/wrapper is executable
+RUN chmod +x /assets/wrapper
+
 # Wrapper to handle signal, trigger runit and reconfigure GitLab
 CMD ["/assets/wrapper"]
 


### PR DESCRIPTION
/assets/wrapper script is missing the exec permission. This will cause the docker container to fail when it is run. To prevent such problem, we'll explicitly set the exec permission when building the docker image.