### PR TITLE
Update to 15.11.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
       matrix:
         include:
           - RELEASE_PACKAGE: gitlab-ce
-            RELEASE_VERSION: 15.11.4-ce.0
-            PUSH_TAGS: 15.11.4-ce.0,15.11.4-ce,15.11-ce,15-ce,ce,latest
+            RELEASE_VERSION: 15.11.6-ce.0
+            PUSH_TAGS: 15.11.6-ce.0,15.11.6-ce,15.11-ce,15-ce,ce,latest
           - RELEASE_PACKAGE: gitlab-ee
-            RELEASE_VERSION: 15.11.4-ee.0
-            PUSH_TAGS: 15.11.4-ee.0,15.11.4-ee,15.11-ee,15-ee,ee
+            RELEASE_VERSION: 15.11.6-ee.0
+            PUSH_TAGS: 15.11.6-ee.0,15.11.6-ee,15.11-ee,15-ee,ee
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Release info: [gitlab-15-11-6-released](https://about.gitlab.com/releases/2023/05/24/gitlab-15-11-6-released/)