### PR TITLE
support new version 15.11.7-ce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,15 @@ ARG RELEASE_ARCH
 
 SHELL ["/bin/sh", "-c"]
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
 # Default to supporting utf-8
-ENV LANG=C.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Install required packages
 RUN apt-get update -q \


### PR DESCRIPTION
Adds unicode locale support.
Without it, the package install breaks with an error.