### PR TITLE
Update Dockerfile, fix warnings about MAINTAINER and ENV format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:22.04
-MAINTAINER GitLab Inc. <support@gitlab.com>
+LABEL maintainer="GitLab Inc. <support@gitlab.com>"
 
 ARG RELEASE_PACKAGE
 ARG RELEASE_VERSION
@@ -33,7 +33,7 @@ RUN apt-get update -q \
     && rm -rf /var/lib/apt/lists/*
 
 # Use BusyBox
-ENV EDITOR /bin/vi
+ENV EDITOR=/bin/vi
 RUN busybox --install \
     && { \
         echo '#!/bin/sh'; \
@@ -60,10 +60,10 @@ RUN chmod -R og-w /assets RELEASE ; \
   /assets/setup
 
 # Allow to access embedded tools
-ENV PATH /opt/gitlab/embedded/bin:/opt/gitlab/bin:/assets:$PATH
+ENV PATH=/opt/gitlab/embedded/bin:/opt/gitlab/bin:/assets:$PATH
 
 # Resolve error: TERM environment variable not set.
-ENV TERM xterm
+ENV TERM=xterm
 
 # Expose web & ssh
 EXPOSE 443 80 22


### PR DESCRIPTION
4 warnings found (use --debug to expand):
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 36)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 63)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 66)